### PR TITLE
Enable biopython >= 1.80, < 1.85

### DIFF
--- a/biopython_convert/__init__.py
+++ b/biopython_convert/__init__.py
@@ -274,6 +274,10 @@ def to_dicts(v):
     :param v: Parent object/list
     :return: list/dict with all children converted to the same
     """
+    try:
+        position_class = SeqFeature.Position
+    except AttributeError:
+        position_class = SeqFeature.AbstractPosition
     if isinstance(v, str):
         try:
             return int(v)
@@ -303,9 +307,9 @@ def to_dicts(v):
         del v['_start']
         del v['_end']
         del v['_strand']
-    elif isinstance(v, SeqFeature.AbstractPosition):
+    elif isinstance(v, position_class):
         return to_dicts(str(v))
-    elif isinstance(v, OrderedDict):
+    elif isinstance(v, (OrderedDict, defaultdict)):
         v = dict(v)
     elif hasattr(v, '__dict__'):
         v = v.__dict__


### PR DESCRIPTION
Biopython 1.80 had two changes that broke Biopython-Convert:

1. All instances of collections.OrderedDict have been replaced by either standard dict or where appropriate by collections.defaultsdict.
2. Base class AbstractPosition was renamed to Position (depricated in 1.80, removed in 1.82)

This PR allows for `biopython >= 1.79, < 1.85`.